### PR TITLE
Potential fix for code scanning alert no. 1: Prototype-polluting function

### DIFF
--- a/src/modules/ConfigModule/ConfigManager.ts
+++ b/src/modules/ConfigModule/ConfigManager.ts
@@ -85,6 +85,9 @@ export class ConfigManager {
     if (typeof target !== "object" || typeof source !== "object") return source;
 
     for (const key of Object.keys(source)) {
+      if (key === "__proto__" || key === "constructor") {
+        continue; // Skip prototype-polluting keys
+      }
       if (source[key] instanceof Object && key in target) {
         target[key] = this.deepMerge(target[key], source[key]);
       } else {


### PR DESCRIPTION
Potential fix for [https://github.com/JaSperryTech-Main/rpg-core-package/security/code-scanning/1](https://github.com/JaSperryTech-Main/rpg-core-package/security/code-scanning/1)

To fix the issue, we need to modify the `deepMerge` function to block the special keys `__proto__` and `constructor` from being copied to the `target` object. This ensures that even if malicious input is provided, it cannot exploit the vulnerability. The fix involves adding a check to skip these keys during the merge process.

Changes will be made to the `deepMerge` function in `src/modules/ConfigModule/ConfigManager.ts`:
1. Add a condition to skip keys named `__proto__` or `constructor`.
2. Ensure that the rest of the functionality remains unchanged.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved security by preventing potential prototype pollution during configuration merging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->